### PR TITLE
add a parameterized command helper with a canExecute hook

### DIFF
--- a/samples/Collections/CollectionSample/Requests.fs
+++ b/samples/Collections/CollectionSample/Requests.fs
@@ -37,9 +37,9 @@ module Requests =
     // using the component defined previously, then maps this to the model-wide update message.
     let requestsComponent = //source (model : ISignal<Requests>) =
         let sorted (requests : Model) = requests |> List.sortBy (fun r -> r.Created)        
-                   
+        let hasRequests = List.isEmpty >> not           
         Component.create<Model,CollectionNav,Message> [
             <@ reqsd.Requests @> |> Bind.collection sorted requestComponentWithNav (fst >> Update)
-            <@ reqsd.Edit @> |> Bind.cmdParam CollectionNav.DisplayRequest |> Bind.toNav
-            <@ reqsd.Info @> |> Bind.cmdParam CollectionNav.ShowRequestDetails |> Bind.toNav
+            <@ reqsd.Edit @> |> Bind.cmdParamIf hasRequests CollectionNav.DisplayRequest |> Bind.toNav
+            <@ reqsd.Info @> |> Bind.cmdParamIf hasRequests CollectionNav.ShowRequestDetails |> Bind.toNav
         ]         

--- a/src/Gjallarhorn.Bindable/Bind.fs
+++ b/src/Gjallarhorn.Bindable/Bind.fs
@@ -526,6 +526,16 @@ module Bind =
             | _ -> failwith "Bad expression"        
             |> Some
 
+    /// Creates a parameterized ICommand (one way property) to a binding source by name which outputs a specific message
+    let cmdParamIf<'Model, 'Nav, 'Param, 'Msg> canExecute (setter : 'Param -> 'Msg) (name : Expr<VmCmd<'Msg>>) : Dispatch<'Nav> -> BindingSource -> ISignal<'Model> -> IObservable<'Msg> option =
+        fun nav (source : BindingSource) (signal : ISignal<'Model>) ->
+            let name = getPropertyNameFromExpression name
+            let canExecuteSignal = signal |> Signal.map canExecute
+            let cmd = Explicit.createCommandParamChecked<'Param> name canExecuteSignal source
+            cmd
+            |> Observable.map setter
+            |> Some
+
     /// Bind a component as a two-way property, acting as a reducer for messages from the component
     let comp<'Model,'Nav,'Msg,'Submodel,'Submsg> (getter : 'Model -> 'Submodel) (componentVm : IComponent<'Submodel, 'Nav, 'Submsg>) (mapper : 'Submsg * 'Submodel -> 'Msg) (name : Expr<'Submodel>) =
         fun nav (source : BindingSource) (signal : ISignal<'Model>) ->


### PR DESCRIPTION
Well that was easy. The `Explicit` module had the exact function I needed.